### PR TITLE
- Add conditional request using ETag

### DIFF
--- a/cuaca/api.py
+++ b/cuaca/api.py
@@ -1,5 +1,7 @@
+import os
+import datetime
+import pickle
 import requests
-
 
 class WeatherAPI(object):
     """
@@ -9,7 +11,7 @@ class WeatherAPI(object):
     url at https://api.met.gov.my/
     """
 
-    def __init__(self, api_key, end_point="https://api.met.gov.my/v2/"):
+    def __init__(self, api_key, end_point="https://api.met.gov.my/v2/", cache_dir=None):
         """
         api = WeatherAPI("API_KEY")
         """
@@ -17,12 +19,47 @@ class WeatherAPI(object):
         self.headers = {
                 "Authorization" : "METToken %s" % api_key
         }
-        self.etag, self.response_etag = None, None
-    
-    def set_etag(self, etag):
-        self.etag = etag
+        self.cache_dir = cache_dir
+        self.cache, self.cache_index = {}, {}
+        self.cache_expiry = datetime.timedelta(days=1)
+        if self.cache_dir:
+            self.load_cache()
 
-    def forecast(self, location_id, start_date, end_date, forecast_type="GENERAL"):
+    def cache_expire(self):
+        now = datetime.datetime.now()
+        for k, v in self.cache_index.items():
+            if now - k >= self.cache_expiry:
+                for c in v:
+                    try:
+                        del self.cache[c]
+                    except:
+                        pass
+
+    def load_cache(self):
+        try:
+            with open(os.path.join(self.cache_dir, "cuaca.p"), "rb") as fp:
+                self.cache = pickle.load(fp)
+        except FileNotFoundError:
+                pass
+        try:
+            with open(os.path.join(self.cache_dir, "cuacaidx.p"), "rb") as fp:
+                self.cache_index = pickle.load(fp)
+            self.cache_expire()
+        except FileNotFoundError:
+            pass
+
+    def save_cache(self):
+        if not self.cache_dir: return
+        self.cache_expire()
+        try:
+            with open(os.path.join(self.cache_dir, "cuaca.p"), "wb") as fp:
+                pickle.dump(self.cache, fp)
+            with open(os.path.join(self.cache_dir, "cuacaidx.p"), "wb") as fp:
+                pickle.dump(self.cache_index, fp)
+        except:
+            raise
+
+    def forecast(self, location_id, start_date, end_date, forecast_type='GENERAL'):
         """
         Get a weather forecast from API
 
@@ -31,9 +68,10 @@ class WeatherAPI(object):
             start_date  - Date in string, format is yyyy-mm-dd
             end_date    - Date in string, format is yyyy-mm-dd
         """
-        if forecast_type not in ("GENERAL", "MARINE"):
-            raise Exception("Error, forecast_type must be GENERAL or MARINE")
+        # there is data type, but only forecast work :-/
         data_url = "{}/{}".format(self.end_point, "data")
+        if forecast_type not in ('GENERAL', 'MARINE'):
+            raise Exception("Error, forecast_type must be GENERAL or MARINE")
         params = {
             "datasetid":"FORECAST", # only this work for data url
             "datacategoryid": forecast_type,
@@ -49,11 +87,11 @@ class WeatherAPI(object):
         GET a list of Locations id from API
 
         Arguments:
-            location_type - string must be STATE, DISTRICT, TOWN, TOURISTDEST, WATERS
+            location_type - string must be STATE, DISTRICT, TOWN, TOURISTDEST
         """
         location_url = "{}/{}".format(self.end_point, "locations")
         if location_type not in ("STATE", "DISTRICT", "TOWN", "TOURISTDEST", "WATERS"):
-            raise Exception("Error, location type must be STATE, DISTRICT, TOWN, TOURISTDEST", "WATERS")
+            raise Exception("Error, location type must be STATE, DISTRICT, TOWN, TOURISTDEST, WATERS")
 
         params = {
             "locationcategoryid": location_type
@@ -70,7 +108,7 @@ class WeatherAPI(object):
 
         Arguments:
             location_name - name of location in string
-            location_type - string must be STATE, DISTRICT, TOWN, TOURISTDEST, WATER
+            location_type - string must be STATE, DISTRICT, TOWN, TOURISTDEST, WATERS
         """
         locations = self.locations(location_type)
         location_id = None
@@ -113,7 +151,7 @@ class WeatherAPI(object):
     def tourist_attraction(self, name):
         
         return self.location(name, "TOURISTDEST")
-    
+
     def waters(self):
         return self.locations("WATERS")
 
@@ -121,21 +159,24 @@ class WeatherAPI(object):
         """
         A utility fuction to make API call easy, wrap around requests
         """
-        # Adding new header - naive way but works for now
-        if self.etag:
-            self.headers['If-None-Match'] = self.etag
+        k = "{}{}".format(url, str(params))
+        if k in self.cache:
+            self.headers["If-None-Match"] = self.cache[k]["etag"]
         r = requests.get(url, headers=self.headers, params=params)
         # Should we maintain api result, metadata can be useful :-/
         if r.status_code == 200:
-            self.response_etag = r.headers.get("ETag", None)
+            etag = r.headers.get("ETag", None)
             data = r.json()
             if metadata:
+                self.cache[k] = {"etag": etag, "result": data["metadata"]}
+                self.cache_index[datetime.datetime.now()] = k
                 return data["metadata"]
             # might fail
+            self.cache[k] = {"etag": etag, "result": data["results"]}
+            self.cache_index[datetime.datetime.now()] = k
             return data["results"]
         elif r.status_code == 304:
-            # Handle If-None-Match: ETag
-            return (304, 'Not modified')
+            return self.cache[k]["result"]
 
         return r.json()
 


### PR DESCRIPTION
The MET API response with, among other, ETag HTTP header. Forecast data are only updated periodically whereby others are kinda like setup/config/param data which are close to constant (even if updated, they'll be rare). The patch enable to use of "If-None-Match" HTTP header. Example usage:
 ```
api = cuaca.WeatherAPI(token)
forecast = api.forecast(location, start_date, end_date)
etag = api.response_etag
```
cache the etag + data + forecast's location/start_date/end_date combo into cache file/memory
```
api.set_etag(etag)
sleep(10)
updated_forecast = api.forecast(location, start_date, end_date) # returns a tuple (304, "Not modified")
```
load data from cache instead